### PR TITLE
build: enhance Maven Central publishing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ gradle-app.setting
 !gradle-wrapper.properties
 .gradletasknamecache
 
+# GPG and Maven Central credentials (never commit these!)
+secring.gpg
+*.gpg
+gradle.properties.local
+
 # Maven (legacy)
 target/
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,8 @@ javacEncoding=UTF-8
 # Generate GPG key: gpg --gen-key
 # List keys with short format: gpg --list-secret-keys --keyid-format=short
 # Use the last 8 characters of the key ID (8-digit format required)
-# Export secret key: gpg --export-secret-keys -o secring.gpg
+# Recommended: Use GPG agent for signing, which keeps your secret key in memory and avoids writing it to disk.
+# Avoid exporting your secret key to a file. If you must, ensure it is stored securely and never committed to version control.
 #signing.keyId=XXXXXXXX
 #signing.password=your-gpg-passphrase
 #signing.secretKeyRingFile=/path/to/secring.gpg

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,30 @@ org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 # Build Options
 javacDebug=true
 javacEncoding=UTF-8
+
+# Maven Central Publishing Configuration
+# IMPORTANT: Do NOT commit these credentials to version control!
+# Instead, add them to ~/.gradle/gradle.properties on your local machine or use environment variables.
+#
+# For Maven Central Publisher Portal:
+# - Releases: https://central.sonatype.com/api/v1/publisher
+# - Snapshots: https://central.sonatype.com/repository/maven-snapshots/
+# Get credentials from: https://central.sonatype.com/account
+#mavenCentralUsername=your-username
+#mavenCentralPassword=your-password
+#
+# For GPG Signing (required for Maven Central):
+# Generate GPG key: gpg --gen-key
+# List keys with short format: gpg --list-secret-keys --keyid-format=short
+# Use the last 8 characters of the key ID (8-digit format required)
+# Export secret key: gpg --export-secret-keys -o secring.gpg
+#signing.keyId=XXXXXXXX
+#signing.password=your-gpg-passphrase
+#signing.secretKeyRingFile=/path/to/secring.gpg
+#
+# Alternatively, use environment variables:
+# export MAVEN_CENTRAL_USERNAME=your-username
+# export MAVEN_CENTRAL_PASSWORD=your-password
+# export SIGNING_KEY_ID=XXXXXXXX
+# export SIGNING_PASSWORD=your-gpg-passphrase
+# export SIGNING_SECRET_KEY_RING_FILE=/path/to/secring.gpg


### PR DESCRIPTION
Improve the Maven Central publishing setup with better credential handling, snapshot repository support, and enhanced security:

- Add flexible signing configuration supporting both in-memory keys and keyring files, with environment variable fallback
- Configure separate URLs for snapshot and release deployments
- Update POM metadata with more accurate project descriptions
- Add comprehensive documentation for publishing credentials setup
- Enhance .gitignore to prevent accidental credential commits
- Fix SCM URL format to use HTTPS for better compatibility

This change makes the publishing process more robust and secure, supporting both local development and CI/CD environments.