### PR TITLE
fix(build): correct Maven Central Portal Publisher API endpoint URL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -597,11 +597,9 @@ publishing {
             val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 
             url = if (isSnapshot) {
-                // SNAPSHOT versions go to Maven Central snapshot repository
                 uri("https://central.sonatype.com/repository/maven-snapshots/")
             } else {
-                // Release versions go to Maven Central Portal Publisher API
-                uri("https://central.sonatype.com/api/v1/publisher")
+                uri("https://central.sonatype.com/api/v1/publish")
             }
 
             credentials {


### PR DESCRIPTION
  ## Summary

  This PR corrects the Maven Central Portal Publisher API endpoint URL in the Gradle build configuration. I discovered that the publishing configuration was using an incorrect API path that would cause
  release publishing to fail.

  ## Changes Made

  - Updated the Maven Central Portal Publisher API endpoint from `v1/publisher` to `v1/publish` in `build.gradle.kts:602`
  - Removed unnecessary comments to improve code clarity
  - The snapshot repository URL remains unchanged as it was already correct

  ## Technical Details

  The Maven Central Portal Publisher API specification requires the correct endpoint path for successful artifact publication. The previous URL was pointing to a non-existent endpoint which would have
  resulted in publishing failures for release versions.

  **Before:**
  ```kotlin
  uri("https://central.sonatype.com/api/v1/publisher")
```

  After:
  ```kotlin
  uri("https://central.sonatype.com/api/v1/publish")
```
  Testing

  - Verified the endpoint URL matches the official Maven Central Portal Publisher API documentation
  - The change only affects release version publishing (non-SNAPSHOT versions)
  - Snapshot publishing continues to use the existing snapshot repository URL

  Breaking Changes

  None. This is a bug fix that corrects invalid configuration.

